### PR TITLE
Properly get image width and height

### DIFF
--- a/resize.php
+++ b/resize.php
@@ -42,8 +42,8 @@ if ( isset( $wp_version ) && version_compare( $wp_version, '3.5' ) >= 0 ) {
 			return new WP_Error( 'no_image_url', __( 'No image URL has been entered.' ), $url );
 
 		// Get default size from database
-		$width = ( $width )  ? get_option( 'thumbnail_size_w' ) : $width;
-		$height = ( $height ) ? get_option( 'thumbnail_size_h' ) : $height;
+		$width = ( $width )  ? $width : get_option( 'thumbnail_size_w' );
+		$height = ( $height ) ? $height : get_option( 'thumbnail_size_h' );
 		  
 		// Allow for different retina sizes
 		$retina = $retina ? ( $retina === true ? 2 : $retina ) : 1;


### PR DESCRIPTION
The previous implementation had an error in its conditional, making it always default to an 150x150px image (the thumbnail defaults). This was due to a reversed conditional.
